### PR TITLE
feat: Redis Pub/Sub 기반 멀티 인스턴스 브로드캐스트 적용

### DIFF
--- a/docs/architecture/m8-pubsub-cross-instance-check.md
+++ b/docs/architecture/m8-pubsub-cross-instance-check.md
@@ -1,0 +1,84 @@
+# M8 Redis Pub/Sub Cross-Instance 검증 기록
+
+## 개요
+
+M8의 목표는 단일 인스턴스 직접 브로드캐스트를 `after-commit Redis Pub/Sub` 기반 다중 인스턴스 브로드캐스트로 바꾸는 것이다. 이 문서는 README 최종 정리 대신, M8 범위에서 실제로 무엇을 검증했는지 남기는 용도다.
+
+## 검증 환경
+
+- 날짜: `2026-04-08`
+- 실행 환경: 로컬 Windows + Docker Desktop
+- 데이터 저장소: Testcontainers `mysql:8.4`, `redis:7.4`
+- 앱 인스턴스:
+  - 인스턴스 A: `@SpringBootTest(webEnvironment = RANDOM_PORT)` 기본 테스트 컨텍스트
+  - 인스턴스 B: 같은 MySQL/Redis를 바라보도록 추가로 띄운 Spring Boot 컨텍스트
+- 고정 외부 계약:
+  - WebSocket endpoint: `/ws-stomp`
+  - SEND destination: `/pub/chat-rooms/{roomId}/messages`
+  - SUBSCRIBE destination: `/sub/chat-rooms/{roomId}`
+
+## 검증 항목
+
+### 1. after-commit publish
+
+`ChatPubSubServiceTest`에서 아래를 확인했다.
+
+- publish 채널이 `chat:events`로 고정되는지
+- 내부 이벤트 payload가 `eventType`, `roomId`, `messageId`, `senderId`, `content`, `type`, `createdAt`만 담는지
+- 트랜잭션 rollback 시 Redis publish가 발생하지 않는지
+
+### 2. 단일 인스턴스 기존 계약 유지
+
+기존 websocket/security 테스트를 그대로 재사용해 아래를 확인했다.
+
+- `ChatMessagingIntegrationTest`
+  - 메시지 저장 후 같은 인스턴스 구독자가 기존 broadcast payload를 받는지
+  - DB에는 메시지가 1건만 저장되는지
+- `WebSocketSecurityIntegrationTest`
+  - CONNECT / SUBSCRIBE / SEND 인증/권한 규칙이 그대로 유지되는지
+
+### 3. cross-instance fan-out
+
+`CrossInstancePubSubScenarioTest`에서 아래 두 시나리오를 검증했다.
+
+- A 인스턴스 송신 -> B 인스턴스 구독자 수신
+- B 인스턴스 송신 -> A 인스턴스 구독자 수신
+
+두 시나리오 모두 `RawStompTestClient`로 실제 STOMP frame을 주고받고, 수신 측이 기존 외부 broadcast payload를 그대로 받는지 확인했다.
+
+## frame excerpt
+
+실제 검증 기준은 테스트 assertion이고, 아래 JSON은 그때 확인한 필드 구조를 옮긴 예시 payload다.
+
+```json
+{
+  "messageId": 1,
+  "roomId": 1,
+  "sender": {
+    "userId": 1,
+    "nickname": "cross-author"
+  },
+  "content": "A to B",
+  "type": "TEXT",
+  "createdAt": "2026-04-08T17:55:00"
+}
+```
+
+핵심은 외부 payload 형식이 바뀌지 않았고, sender nickname도 현재 `users.nickname` 기준으로 조립된다는 점이다.
+
+## 실행 명령
+
+M8 확인에 사용한 명령은 아래와 같다.
+
+```powershell
+./gradlew.bat test --tests "io.github.nanmazino.chatrebuild.chat.pubsub.ChatPubSubServiceTest" --tests "io.github.nanmazino.chatrebuild.chat.controller.ChatMessagingIntegrationTest" --tests "io.github.nanmazino.chatrebuild.chat.controller.WebSocketSecurityIntegrationTest" --tests "io.github.nanmazino.chatrebuild.scenario.CrossInstancePubSubScenarioTest"
+./gradlew.bat test
+```
+
+## 정리
+
+이번 단계에서 확인한 것은 다음 한 줄이다.
+
+`메시지 저장 -> summary 반영 -> commit -> Redis publish -> 각 인스턴스 listener -> 로컬 WebSocket fan-out`
+
+읽음 처리, `unreadCount`, README/ERD/API 최종 동기화는 이 문서 범위에 포함하지 않는다.

--- a/docs/architecture/redis-direction-plan.md
+++ b/docs/architecture/redis-direction-plan.md
@@ -32,7 +32,7 @@
 
 room summary 응답은 `postTitle`, `memberCount`, `lastMessageId`, `lastMessagePreview`, `lastMessageAt`처럼 방 단위 상태만 담는다. 사용자별 `unreadCount`가 없기 때문에 뒤 마일스톤의 읽음 처리와 직접 충돌하지 않는다. 이 점이 room list와 가장 큰 차이다.
 
-따라서 room summary cache는 “모든 방에 일괄 적용”이 아니라, 최근 일정 시간 동안 새 메시지가 없는 휴면 방에만 적용하는 것이 타당하다. 예를 들어 `lastMessageAt`이 있으면 그 시각을 기준으로 30분 이상 지난 방만 cache 대상으로 보고, `lastMessageAt`이 `null`인 방은 생성 시각 기준으로 30분 이상 지난 경우에만 포함한다. TTL은 1시간 정도로 길게 둔다. 정확성은 TTL이 아니라 기존의 after-commit eviction으로 맞춘다. 즉, 메시지 전송, 참여/나가기, 게시글 제목 수정 시에는 지금처럼 cache를 비우고, 조용한 기간에는 반복 조회를 Redis가 흡수하게 한다.
+따라서 room summary cache는 “모든 방에 일괄 적용”이 아니라, 최근 일정 시간 동안 새 메시지가 없는 휴면 방에만 적용하는 것이 타당하다. 예를 들어 `lastMessageAt`이 있으면 그 시각을 기준으로 30분 이상 지난 방만 cache 대상으로 보고, `lastMessageAt`이 `null`인 방은 생성 시각 기준으로 30분 이상 지난 경우에만 포함한다. TTL은 1시간 정도로 길게 둔다. 정확성은 TTL이 아니라 기존의 after-commit eviction으로 맞춘다. 즉, 메시지 전송, 참여/나가기, 게시글 수정(`updatePost`) 시에는 지금처럼 cache를 비우고, 조용한 기간에는 반복 조회를 Redis가 흡수하게 한다.
 
 이 cache는 핵심 성능 전략이 아니라 범위를 좁힌 보조 최적화로 설명해야 한다. Redis의 대표 역할을 summary cache에 두지는 않는다.
 

--- a/src/main/java/io/github/nanmazino/chatrebuild/chat/cache/ChatCacheService.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/chat/cache/ChatCacheService.java
@@ -1,13 +1,12 @@
 package io.github.nanmazino.chatrebuild.chat.cache;
 
 import io.github.nanmazino.chatrebuild.chat.dto.response.ChatRoomDetailResponse;
+import io.github.nanmazino.chatrebuild.global.util.AfterCommitExecutor;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.support.TransactionSynchronization;
-import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 @Service
 @RequiredArgsConstructor
@@ -15,6 +14,7 @@ public class ChatCacheService {
 
     private static final Logger log = LoggerFactory.getLogger(ChatCacheService.class);
 
+    private final AfterCommitExecutor afterCommitExecutor;
     private final ChatCacheRepository chatCacheRepository;
 
     public Optional<ChatRoomDetailResponse> findRoomSummary(Long roomId) {
@@ -35,7 +35,7 @@ public class ChatCacheService {
     }
 
     public void evictRoomSummaryAfterCommit(Long roomId) {
-        runAfterCommit(() -> evictRoomSummary(roomId));
+        afterCommitExecutor.run(() -> evictRoomSummary(roomId));
     }
 
     public void evictRoomSummary(Long roomId) {
@@ -44,19 +44,5 @@ public class ChatCacheService {
         } catch (RuntimeException exception) {
             log.warn("Redis room summary cache eviction failed. Keeping DB commit. roomId={}", roomId, exception);
         }
-    }
-
-    private void runAfterCommit(Runnable action) {
-        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
-            action.run();
-            return;
-        }
-
-        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
-            @Override
-            public void afterCommit() {
-                action.run();
-            }
-        });
     }
 }

--- a/src/main/java/io/github/nanmazino/chatrebuild/chat/controller/ChatStompController.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/chat/controller/ChatStompController.java
@@ -1,7 +1,6 @@
 package io.github.nanmazino.chatrebuild.chat.controller;
 
 import io.github.nanmazino.chatrebuild.chat.dto.request.ChatSendRequest;
-import io.github.nanmazino.chatrebuild.chat.dto.response.ChatMessageResponse;
 import io.github.nanmazino.chatrebuild.chat.service.ChatMessageService;
 import io.github.nanmazino.chatrebuild.global.security.JwtPrincipal;
 import java.security.Principal;
@@ -9,7 +8,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.DestinationVariable;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
-import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.security.authentication.AuthenticationCredentialsNotFoundException;
 import org.springframework.security.core.Authentication;
 import org.springframework.stereotype.Controller;
@@ -19,7 +17,6 @@ import org.springframework.stereotype.Controller;
 public class ChatStompController {
 
     private final ChatMessageService chatMessageService;
-    private final SimpMessagingTemplate messagingTemplate;
 
     @MessageMapping("/chat-rooms/{roomId}/messages")
     public void sendMessage(
@@ -28,9 +25,7 @@ public class ChatStompController {
         Principal principal
     ) {
         JwtPrincipal jwtPrincipal = extractJwtPrincipal(principal);
-        ChatMessageResponse response = chatMessageService.sendMessage(roomId, jwtPrincipal.userId(), request);
-
-        messagingTemplate.convertAndSend("/sub/chat-rooms/" + roomId, response);
+        chatMessageService.sendMessage(roomId, jwtPrincipal.userId(), request);
     }
 
     private JwtPrincipal extractJwtPrincipal(Principal principal) {

--- a/src/main/java/io/github/nanmazino/chatrebuild/chat/pubsub/ChatMessageCreatedEvent.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/chat/pubsub/ChatMessageCreatedEvent.java
@@ -1,0 +1,40 @@
+package io.github.nanmazino.chatrebuild.chat.pubsub;
+
+import io.github.nanmazino.chatrebuild.chat.dto.response.ChatMessageResponse;
+import io.github.nanmazino.chatrebuild.chat.entity.ChatMessage;
+import io.github.nanmazino.chatrebuild.chat.entity.ChatMessageType;
+import java.time.LocalDateTime;
+
+public record ChatMessageCreatedEvent(
+    ChatPubSubEventType eventType,
+    Long roomId,
+    Long messageId,
+    Long senderId,
+    String content,
+    ChatMessageType type,
+    LocalDateTime createdAt
+) {
+
+    public static ChatMessageCreatedEvent from(ChatMessage message) {
+        return new ChatMessageCreatedEvent(
+            ChatPubSubEventType.CHAT_MESSAGE_CREATED,
+            message.getRoom().getId(),
+            message.getId(),
+            message.getSender().getId(),
+            message.getContent(),
+            message.getType(),
+            message.getCreatedAt()
+        );
+    }
+
+    public ChatMessageResponse toChatMessageResponse(String senderNickname) {
+        return new ChatMessageResponse(
+            messageId,
+            roomId,
+            new ChatMessageResponse.Sender(senderId, senderNickname),
+            content,
+            type,
+            createdAt
+        );
+    }
+}

--- a/src/main/java/io/github/nanmazino/chatrebuild/chat/pubsub/ChatPubSubEventType.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/chat/pubsub/ChatPubSubEventType.java
@@ -1,0 +1,5 @@
+package io.github.nanmazino.chatrebuild.chat.pubsub;
+
+public enum ChatPubSubEventType {
+    CHAT_MESSAGE_CREATED
+}

--- a/src/main/java/io/github/nanmazino/chatrebuild/chat/pubsub/ChatPubSubService.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/chat/pubsub/ChatPubSubService.java
@@ -1,0 +1,68 @@
+package io.github.nanmazino.chatrebuild.chat.pubsub;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.nanmazino.chatrebuild.chat.dto.response.ChatMessageResponse;
+import io.github.nanmazino.chatrebuild.chat.websocket.ChatWebSocketBroadcaster;
+import io.github.nanmazino.chatrebuild.global.util.AfterCommitExecutor;
+import io.github.nanmazino.chatrebuild.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ChatPubSubService {
+
+    public static final String CHANNEL_NAME = "chat:events";
+
+    private static final Logger log = LoggerFactory.getLogger(ChatPubSubService.class);
+
+    private final AfterCommitExecutor afterCommitExecutor;
+    private final StringRedisTemplate stringRedisTemplate;
+    private final ObjectMapper objectMapper;
+    private final UserRepository userRepository;
+    private final ChatWebSocketBroadcaster chatWebSocketBroadcaster;
+
+    public void publishMessageCreatedAfterCommit(ChatMessageCreatedEvent event) {
+        afterCommitExecutor.run(() -> publishMessageCreated(event));
+    }
+
+    public void handlePublishedMessage(String payload) {
+        try {
+            ChatMessageCreatedEvent event = objectMapper.readValue(payload, ChatMessageCreatedEvent.class);
+            handleMessageCreatedEvent(event);
+        } catch (JsonProcessingException | RuntimeException exception) {
+            log.warn("Redis Pub/Sub message handling failed. payload={}", payload, exception);
+        }
+    }
+
+    private void publishMessageCreated(ChatMessageCreatedEvent event) {
+        try {
+            String payload = objectMapper.writeValueAsString(event);
+            stringRedisTemplate.convertAndSend(CHANNEL_NAME, payload);
+        } catch (JsonProcessingException | RuntimeException exception) {
+            log.warn("Redis Pub/Sub publish failed. eventType={}, roomId={}, messageId={}",
+                event.eventType(),
+                event.roomId(),
+                event.messageId(),
+                exception
+            );
+        }
+    }
+
+    private void handleMessageCreatedEvent(ChatMessageCreatedEvent event) {
+        if (event.eventType() != ChatPubSubEventType.CHAT_MESSAGE_CREATED) {
+            log.warn("Unsupported Redis Pub/Sub event type. eventType={}", event.eventType());
+            return;
+        }
+
+        String senderNickname = userRepository.findNicknameById(event.senderId())
+            .orElseThrow(() -> new IllegalStateException("메시지 발신자 닉네임을 찾을 수 없습니다."));
+        ChatMessageResponse response = event.toChatMessageResponse(senderNickname);
+
+        chatWebSocketBroadcaster.broadcast(response);
+    }
+}

--- a/src/main/java/io/github/nanmazino/chatrebuild/chat/service/ChatMessageService.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/chat/service/ChatMessageService.java
@@ -6,6 +6,8 @@ import io.github.nanmazino.chatrebuild.chat.dto.response.ChatMessageHistoryRespo
 import io.github.nanmazino.chatrebuild.chat.dto.response.ChatMessageResponse;
 import io.github.nanmazino.chatrebuild.chat.entity.ChatMessage;
 import io.github.nanmazino.chatrebuild.chat.entity.ChatRoomMember;
+import io.github.nanmazino.chatrebuild.chat.pubsub.ChatMessageCreatedEvent;
+import io.github.nanmazino.chatrebuild.chat.pubsub.ChatPubSubService;
 import io.github.nanmazino.chatrebuild.chat.exception.InvalidChatMessageCursorException;
 import io.github.nanmazino.chatrebuild.chat.repository.ChatMessageHistoryProjection;
 import io.github.nanmazino.chatrebuild.chat.repository.ChatMessageRepository;
@@ -21,6 +23,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ChatMessageService {
 
     private final ChatCacheService chatCacheService;
+    private final ChatPubSubService chatPubSubService;
     private final ChatMembershipService chatMembershipService;
     private final ChatMessageRepository chatMessageRepository;
 
@@ -62,6 +65,7 @@ public class ChatMessageService {
             savedMessage.getCreatedAt()
         );
         chatCacheService.evictRoomSummaryAfterCommit(activeMember.getRoom().getId());
+        chatPubSubService.publishMessageCreatedAfterCommit(ChatMessageCreatedEvent.from(savedMessage));
 
         return ChatMessageResponse.from(savedMessage);
     }

--- a/src/main/java/io/github/nanmazino/chatrebuild/chat/websocket/ChatWebSocketBroadcaster.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/chat/websocket/ChatWebSocketBroadcaster.java
@@ -1,0 +1,17 @@
+package io.github.nanmazino.chatrebuild.chat.websocket;
+
+import io.github.nanmazino.chatrebuild.chat.dto.response.ChatMessageResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ChatWebSocketBroadcaster {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void broadcast(ChatMessageResponse response) {
+        messagingTemplate.convertAndSend("/sub/chat-rooms/" + response.roomId(), response);
+    }
+}

--- a/src/main/java/io/github/nanmazino/chatrebuild/global/config/RedisConfig.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/global/config/RedisConfig.java
@@ -1,11 +1,14 @@
 package io.github.nanmazino.chatrebuild.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.nanmazino.chatrebuild.chat.pubsub.ChatPubSubService;
 import io.github.nanmazino.chatrebuild.chat.dto.response.ChatRoomDetailResponse;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.serializer.Jackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -38,5 +41,28 @@ public class RedisConfig {
         redisTemplate.afterPropertiesSet();
 
         return redisTemplate;
+    }
+
+    @Bean
+    public RedisMessageListenerContainer redisMessageListenerContainer(
+        RedisConnectionFactory redisConnectionFactory,
+        ChatPubSubService chatPubSubService
+    ) {
+        RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+        StringRedisSerializer serializer = new StringRedisSerializer();
+
+        container.setConnectionFactory(redisConnectionFactory);
+        container.addMessageListener(
+            (message, pattern) -> {
+                String payload = serializer.deserialize(message.getBody());
+
+                if (payload != null) {
+                    chatPubSubService.handlePublishedMessage(payload);
+                }
+            },
+            new ChannelTopic(ChatPubSubService.CHANNEL_NAME)
+        );
+
+        return container;
     }
 }

--- a/src/main/java/io/github/nanmazino/chatrebuild/global/util/AfterCommitExecutor.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/global/util/AfterCommitExecutor.java
@@ -1,0 +1,23 @@
+package io.github.nanmazino.chatrebuild.global.util;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+@Component
+public class AfterCommitExecutor {
+
+    public void run(Runnable action) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            action.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+            @Override
+            public void afterCommit() {
+                action.run();
+            }
+        });
+    }
+}

--- a/src/main/java/io/github/nanmazino/chatrebuild/user/repository/UserRepository.java
+++ b/src/main/java/io/github/nanmazino/chatrebuild/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package io.github.nanmazino.chatrebuild.user.repository;
 import io.github.nanmazino.chatrebuild.user.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
@@ -11,4 +13,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByNickname(String nickname);
+
+    @Query("""
+        select user.nickname
+        from User user
+        where user.id = :userId
+        """)
+    Optional<String> findNicknameById(@Param("userId") Long userId);
 }

--- a/src/test/java/io/github/nanmazino/chatrebuild/chat/pubsub/ChatPubSubServiceTest.java
+++ b/src/test/java/io/github/nanmazino/chatrebuild/chat/pubsub/ChatPubSubServiceTest.java
@@ -1,0 +1,176 @@
+package io.github.nanmazino.chatrebuild.chat.pubsub;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.nanmazino.chatrebuild.chat.dto.response.ChatMessageResponse;
+import io.github.nanmazino.chatrebuild.chat.entity.ChatMessageType;
+import io.github.nanmazino.chatrebuild.chat.websocket.ChatWebSocketBroadcaster;
+import io.github.nanmazino.chatrebuild.support.IntegrationTestSupport;
+import io.github.nanmazino.chatrebuild.user.entity.User;
+import io.github.nanmazino.chatrebuild.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class ChatPubSubServiceTest extends IntegrationTestSupport {
+
+    @Autowired
+    private ChatPubSubService chatPubSubService;
+
+    @Autowired
+    private ChatPubSubRollbackTestHelper rollbackTestHelper;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @MockitoSpyBean
+    private StringRedisTemplate stringRedisTemplate;
+
+    @MockitoSpyBean
+    private ChatWebSocketBroadcaster chatWebSocketBroadcaster;
+
+    @BeforeEach
+    void setUp() {
+        clearInvocations(stringRedisTemplate, chatWebSocketBroadcaster);
+    }
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+    @Test
+    @DisplayName("메시지 생성 이벤트 publish는 chat:events 채널에 문서 기준 payload로 발행한다")
+    void publishMessageCreatedAfterCommitUsesFixedChannelAndPayload() throws Exception {
+        ChatMessageCreatedEvent event = new ChatMessageCreatedEvent(
+            ChatPubSubEventType.CHAT_MESSAGE_CREATED,
+            3L,
+            120L,
+            7L,
+            "오늘 7시로 확정할게요",
+            ChatMessageType.TEXT,
+            LocalDateTime.of(2026, 4, 8, 17, 0)
+        );
+        doReturn(1L).when(stringRedisTemplate).convertAndSend(anyString(), anyString());
+
+        chatPubSubService.publishMessageCreatedAfterCommit(event);
+
+        ArgumentCaptor<String> channelCaptor = ArgumentCaptor.forClass(String.class);
+        ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+        verify(stringRedisTemplate).convertAndSend(channelCaptor.capture(), payloadCaptor.capture());
+
+        JsonNode payload = objectMapper.readTree(payloadCaptor.getValue());
+
+        assertThat(channelCaptor.getValue()).isEqualTo(ChatPubSubService.CHANNEL_NAME);
+        assertThat(payload.path("eventType").asText()).isEqualTo("CHAT_MESSAGE_CREATED");
+        assertThat(payload.path("roomId").asLong()).isEqualTo(3L);
+        assertThat(payload.path("messageId").asLong()).isEqualTo(120L);
+        assertThat(payload.path("senderId").asLong()).isEqualTo(7L);
+        assertThat(payload.path("content").asText()).isEqualTo("오늘 7시로 확정할게요");
+        assertThat(payload.path("type").asText()).isEqualTo("TEXT");
+        assertThat(payload.path("createdAt").asText()).isEqualTo("2026-04-08T17:00:00");
+    }
+
+    @Test
+    @DisplayName("Redis Pub/Sub 수신 payload는 현재 사용자 닉네임 기준 ChatMessageResponse로 fan-out 한다")
+    void handlePublishedMessageBroadcastsUsingCurrentUserNickname() throws Exception {
+        User sender = userRepository.save(new User("pubsub-sender@test.com", "pw", "current-nickname"));
+        ChatMessageCreatedEvent event = new ChatMessageCreatedEvent(
+            ChatPubSubEventType.CHAT_MESSAGE_CREATED,
+            5L,
+            88L,
+            sender.getId(),
+            "redis fan-out",
+            ChatMessageType.TEXT,
+            LocalDateTime.of(2026, 4, 8, 17, 5)
+        );
+        String payload = objectMapper.writeValueAsString(event);
+        doNothing().when(chatWebSocketBroadcaster).broadcast(any(ChatMessageResponse.class));
+
+        chatPubSubService.handlePublishedMessage(payload);
+
+        ArgumentCaptor<ChatMessageResponse> responseCaptor = ArgumentCaptor.forClass(ChatMessageResponse.class);
+        verify(chatWebSocketBroadcaster).broadcast(responseCaptor.capture());
+
+        ChatMessageResponse response = responseCaptor.getValue();
+
+        assertThat(response.roomId()).isEqualTo(5L);
+        assertThat(response.messageId()).isEqualTo(88L);
+        assertThat(response.sender().userId()).isEqualTo(sender.getId());
+        assertThat(response.sender().nickname()).isEqualTo("current-nickname");
+        assertThat(response.content()).isEqualTo("redis fan-out");
+        assertThat(response.type()).isEqualTo(ChatMessageType.TEXT);
+        assertThat(response.createdAt()).isEqualTo(LocalDateTime.of(2026, 4, 8, 17, 5));
+    }
+
+    @Test
+    @DisplayName("트랜잭션이 rollback 되면 Redis publish는 발생하지 않는다")
+    void publishMessageCreatedAfterCommitSkipsPublishOnRollback() {
+        ChatMessageCreatedEvent event = new ChatMessageCreatedEvent(
+            ChatPubSubEventType.CHAT_MESSAGE_CREATED,
+            9L,
+            321L,
+            12L,
+            "rollback",
+            ChatMessageType.TEXT,
+            LocalDateTime.of(2026, 4, 8, 17, 10)
+        );
+        doReturn(1L).when(stringRedisTemplate).convertAndSend(anyString(), anyString());
+
+        assertThatThrownBy(() -> rollbackTestHelper.publishThenRollback(event))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("force rollback");
+
+        verify(stringRedisTemplate, never()).convertAndSend(anyString(), anyString());
+    }
+
+    @TestConfiguration
+    static class ChatPubSubTestConfig {
+
+        @Bean
+        ChatPubSubRollbackTestHelper chatPubSubRollbackTestHelper(ChatPubSubService chatPubSubService) {
+            return new ChatPubSubRollbackTestHelper(chatPubSubService);
+        }
+    }
+
+    static class ChatPubSubRollbackTestHelper {
+
+        private final ChatPubSubService chatPubSubService;
+
+        ChatPubSubRollbackTestHelper(ChatPubSubService chatPubSubService) {
+            this.chatPubSubService = chatPubSubService;
+        }
+
+        @Transactional
+        public void publishThenRollback(ChatMessageCreatedEvent event) {
+            chatPubSubService.publishMessageCreatedAfterCommit(event);
+            throw new IllegalStateException("force rollback");
+        }
+    }
+}

--- a/src/test/java/io/github/nanmazino/chatrebuild/scenario/CrossInstancePubSubScenarioTest.java
+++ b/src/test/java/io/github/nanmazino/chatrebuild/scenario/CrossInstancePubSubScenarioTest.java
@@ -1,0 +1,220 @@
+package io.github.nanmazino.chatrebuild.scenario;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.github.nanmazino.chatrebuild.ChatRebuildApplication;
+import io.github.nanmazino.chatrebuild.chat.entity.ChatRoom;
+import io.github.nanmazino.chatrebuild.chat.entity.ChatRoomMember;
+import io.github.nanmazino.chatrebuild.chat.entity.ChatRoomMemberStatus;
+import io.github.nanmazino.chatrebuild.chat.repository.ChatMessageRepository;
+import io.github.nanmazino.chatrebuild.chat.repository.ChatRoomMemberRepository;
+import io.github.nanmazino.chatrebuild.chat.repository.ChatRoomRepository;
+import io.github.nanmazino.chatrebuild.global.security.JwtTokenProvider;
+import io.github.nanmazino.chatrebuild.post.entity.Post;
+import io.github.nanmazino.chatrebuild.post.entity.PostStatus;
+import io.github.nanmazino.chatrebuild.post.repository.PostRepository;
+import io.github.nanmazino.chatrebuild.support.IntegrationTestSupport;
+import io.github.nanmazino.chatrebuild.support.RawStompTestClient;
+import io.github.nanmazino.chatrebuild.user.entity.User;
+import io.github.nanmazino.chatrebuild.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.boot.web.context.WebServerApplicationContext;
+import org.springframework.context.ConfigurableApplicationContext;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@ActiveProfiles("test")
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+class CrossInstancePubSubScenarioTest extends IntegrationTestSupport {
+
+    @LocalServerPort
+    private int primaryPort;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PostRepository postRepository;
+
+    @Autowired
+    private ChatRoomRepository chatRoomRepository;
+
+    @Autowired
+    private ChatRoomMemberRepository chatRoomMemberRepository;
+
+    @Autowired
+    private ChatMessageRepository chatMessageRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private ConfigurableApplicationContext secondaryContext;
+    private int secondaryPort;
+    private RawStompTestClient primaryStompClient;
+    private RawStompTestClient secondaryStompClient;
+    private User author;
+    private User member;
+    private ChatRoom room;
+
+    @BeforeAll
+    void startSecondaryInstance() {
+        secondaryContext = new SpringApplicationBuilder(ChatRebuildApplication.class)
+            .profiles("test")
+            .properties(
+                "server.port=0",
+                "spring.datasource.url=" + MYSQL_CONTAINER.getJdbcUrl(),
+                "spring.datasource.username=" + MYSQL_CONTAINER.getUsername(),
+                "spring.datasource.password=" + MYSQL_CONTAINER.getPassword(),
+                "spring.datasource.driver-class-name=" + MYSQL_CONTAINER.getDriverClassName(),
+                "spring.data.redis.host=" + REDIS_CONTAINER.getHost(),
+                "spring.data.redis.port=" + REDIS_CONTAINER.getMappedPort(6379),
+                "spring.jpa.hibernate.ddl-auto=none"
+            )
+            .run();
+        secondaryPort = ((WebServerApplicationContext) secondaryContext).getWebServer().getPort();
+    }
+
+    @BeforeEach
+    void setUp() {
+        chatMessageRepository.deleteAllInBatch();
+        chatRoomMemberRepository.deleteAllInBatch();
+        chatRoomRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+
+        author = saveUser("cross-author@test.com", "cross-author");
+        member = saveUser("cross-member@test.com", "cross-member");
+        room = createRoom("cross-room", PostStatus.OPEN);
+        addActiveMember(room, author);
+        addActiveMember(room, member);
+
+        primaryStompClient = new RawStompTestClient(primaryPort);
+        secondaryStompClient = new RawStompTestClient(secondaryPort);
+    }
+
+    @AfterEach
+    void tearDown() throws Exception {
+        if (primaryStompClient != null) {
+            primaryStompClient.close();
+        }
+
+        if (secondaryStompClient != null) {
+            secondaryStompClient.close();
+        }
+
+        chatMessageRepository.deleteAllInBatch();
+        chatRoomMemberRepository.deleteAllInBatch();
+        chatRoomRepository.deleteAllInBatch();
+        postRepository.deleteAllInBatch();
+        userRepository.deleteAllInBatch();
+    }
+
+    @AfterAll
+    void closeSecondaryInstance() {
+        if (secondaryContext != null) {
+            secondaryContext.close();
+        }
+    }
+
+    @Test
+    @DisplayName("A 인스턴스에서 보낸 메시지는 B 인스턴스 구독자에게 전달된다")
+    void messageSentFromPrimaryInstanceIsDeliveredToSecondarySubscriber() throws Exception {
+        RawStompTestClient.Connection subscriberConnection = secondaryStompClient.connect(accessToken(member));
+        subscriberConnection.send(RawStompTestClient.subscribeFrame(room.getId()));
+        subscriberConnection.assertNoFrame();
+
+        RawStompTestClient.Connection senderConnection = primaryStompClient.connect(accessToken(author));
+        senderConnection.send(RawStompTestClient.sendFrame(room.getId(), """
+            {
+              "content": "A to B",
+              "type": "TEXT"
+            }
+            """));
+
+        String frame = subscriberConnection.awaitFrame();
+        JsonNode body = RawStompTestClient.parseBody(objectMapper, frame);
+
+        assertThat(RawStompTestClient.frameCommand(frame)).isEqualTo("MESSAGE");
+        assertThat(body.path("roomId").asLong()).isEqualTo(room.getId());
+        assertThat(body.path("sender").path("userId").asLong()).isEqualTo(author.getId());
+        assertThat(body.path("sender").path("nickname").asText()).isEqualTo(author.getNickname());
+        assertThat(body.path("content").asText()).isEqualTo("A to B");
+        assertThat(body.path("type").asText()).isEqualTo("TEXT");
+        assertThat(chatMessageRepository.countByRoomId(room.getId())).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("B 인스턴스에서 보낸 메시지는 A 인스턴스 구독자에게 전달된다")
+    void messageSentFromSecondaryInstanceIsDeliveredToPrimarySubscriber() throws Exception {
+        RawStompTestClient.Connection subscriberConnection = primaryStompClient.connect(accessToken(author));
+        subscriberConnection.send(RawStompTestClient.subscribeFrame(room.getId()));
+        subscriberConnection.assertNoFrame();
+
+        RawStompTestClient.Connection senderConnection = secondaryStompClient.connect(accessToken(member));
+        senderConnection.send(RawStompTestClient.sendFrame(room.getId(), """
+            {
+              "content": "B to A",
+              "type": "TEXT"
+            }
+            """));
+
+        String frame = subscriberConnection.awaitFrame();
+        JsonNode body = RawStompTestClient.parseBody(objectMapper, frame);
+
+        assertThat(RawStompTestClient.frameCommand(frame)).isEqualTo("MESSAGE");
+        assertThat(body.path("roomId").asLong()).isEqualTo(room.getId());
+        assertThat(body.path("sender").path("userId").asLong()).isEqualTo(member.getId());
+        assertThat(body.path("sender").path("nickname").asText()).isEqualTo(member.getNickname());
+        assertThat(body.path("content").asText()).isEqualTo("B to A");
+        assertThat(body.path("type").asText()).isEqualTo("TEXT");
+        assertThat(chatMessageRepository.countByRoomId(room.getId())).isEqualTo(1);
+    }
+
+    private String accessToken(User user) {
+        return jwtTokenProvider.generateAccessToken(user.getId(), user.getEmail());
+    }
+
+    private User saveUser(String email, String nickname) {
+        return userRepository.save(new User(
+            email,
+            passwordEncoder.encode("Password123!"),
+            nickname
+        ));
+    }
+
+    private ChatRoom createRoom(String title, PostStatus status) {
+        Post post = postRepository.save(new Post(author, title, title + "-content", 4, status));
+        return chatRoomRepository.save(new ChatRoom(post));
+    }
+
+    private void addActiveMember(ChatRoom chatRoom, User user) {
+        chatRoomMemberRepository.save(new ChatRoomMember(
+            chatRoom,
+            user,
+            ChatRoomMemberStatus.ACTIVE,
+            LocalDateTime.now()
+        ));
+        chatRoom.increaseMemberCount();
+        chatRoomRepository.saveAndFlush(chatRoom);
+    }
+}


### PR DESCRIPTION
## 요약
- 메시지 저장 이후 브로드캐스트 경로를 직접 fan-out에서 `after-commit Redis Pub/Sub` 기반으로 전환했습니다.
- 각 인스턴스는 Redis `chat:events` 채널을 구독해 로컬 WebSocket 세션으로만 fan-out하고, 외부 STOMP payload 계약은 그대로 유지합니다.
- Pub/Sub 단위 테스트와 2개 인스턴스 cross-instance 시나리오 테스트를 추가했고, M8 검증 기록과 Redis 방향 문서를 함께 정리했습니다.

## 관련 이슈
- Closes #47
- Closes #48

## 변경 사항
- `ChatPubSubService`, `ChatMessageCreatedEvent`, `ChatPubSubEventType`, `ChatWebSocketBroadcaster`, `AfterCommitExecutor`를 추가해 `commit -> Redis publish -> listener -> local WebSocket fan-out` 흐름을 분리했습니다.
- `ChatMessageService`, `ChatStompController`, `RedisConfig`, `ChatCacheService`, `UserRepository`를 조정해 메시지 저장 후 summary 갱신 다음에만 publish가 예약되고, listener는 `senderId`로 현재 nickname을 조회해 기존 `ChatMessageResponse` payload를 조립하도록 맞췄습니다.
- `ChatPubSubServiceTest`에서 publish payload, subscribe 처리, rollback 시 publish 미발생을 검증하고, `CrossInstancePubSubScenarioTest`에서 A 송신 -> B 수신 / B 송신 -> A 수신 시나리오를 추가했습니다.
- `docs/architecture/m8-pubsub-cross-instance-check.md`에 M8 검증 기록을 남기고, `docs/architecture/redis-direction-plan.md`에 room summary cache와 Pub/Sub 방향 문구를 현재 구현 기준으로 정리했습니다.

## 검증
- `./gradlew.bat test --tests "io.github.nanmazino.chatrebuild.chat.pubsub.ChatPubSubServiceTest" --tests "io.github.nanmazino.chatrebuild.chat.controller.ChatMessagingIntegrationTest" --tests "io.github.nanmazino.chatrebuild.chat.controller.WebSocketSecurityIntegrationTest" --tests "io.github.nanmazino.chatrebuild.scenario.CrossInstancePubSubScenarioTest"`
- `./gradlew.bat test`
