### PR TITLE
test: 채팅 회귀 테스트 보강

### DIFF
--- a/src/test/java/io/github/nanmazino/chatrebuild/chat/controller/ChatMessagingIntegrationTest.java
+++ b/src/test/java/io/github/nanmazino/chatrebuild/chat/controller/ChatMessagingIntegrationTest.java
@@ -100,48 +100,65 @@ class ChatMessagingIntegrationTest extends IntegrationTestSupport {
     @Test
     @DisplayName("메시지를 보내면 저장되고 같은 인스턴스 구독자에게 principal sender 기준으로 브로드캐스트된다")
     void sendMessageBroadcastsAndPersistsUsingPrincipalSender() throws Exception {
-        RawStompTestClient.Connection subscriberConnection = stompClient.connect(accessToken(subscriber));
-        subscriberConnection.send(RawStompTestClient.subscribeFrame(room.getId()));
-        subscriberConnection.assertNoFrame();
+        assertMessageBroadcastsAndPersists(
+            room,
+            author,
+            subscriber,
+            """
+                {
+                  "content": "오늘 7시로 확정할게요",
+                  "type": "TEXT",
+                  "senderId": 999,
+                  "nickname": "intruder",
+                  "sender": {
+                    "userId": 999,
+                    "nickname": "intruder"
+                  }
+                }
+                """,
+            author,
+            "오늘 7시로 확정할게요"
+        );
+    }
 
-        RawStompTestClient.Connection senderConnection = stompClient.connect(accessToken(author));
-        senderConnection.send(RawStompTestClient.sendFrame(room.getId(), """
-            {
-              "content": "오늘 7시로 확정할게요",
-              "type": "TEXT",
-              "senderId": 999,
-              "nickname": "intruder",
-              "sender": {
-                "userId": 999,
-                "nickname": "intruder"
-              }
-            }
-            """));
+    @Test
+    @DisplayName("CLOSED 게시글의 ACTIVE 멤버 메시지는 저장되고 구독자에게 브로드캐스트된다")
+    void sendMessageBroadcastsAndPersistsForClosedPostActiveMembers() throws Exception {
+        ChatRoom closedRoom = createRoomWithActiveMembers("closed-room", PostStatus.CLOSED, author, subscriber);
 
-        String frame = subscriberConnection.awaitFrame();
-        JsonNode body = RawStompTestClient.parseBody(objectMapper, frame);
-        ChatMessage savedMessage = chatMessageRepository.findAll().stream()
-            .findFirst()
-            .orElseThrow(() -> new AssertionError("저장된 메시지가 있어야 합니다."));
-        ChatRoom refreshedRoom = chatRoomRepository.findById(room.getId())
-            .orElseThrow(() -> new AssertionError("채팅방이 유지되어야 합니다."));
+        assertMessageBroadcastsAndPersists(
+            closedRoom,
+            author,
+            subscriber,
+            """
+                {
+                  "content": "마감 이후 기존 멤버 대화",
+                  "type": "TEXT"
+                }
+                """,
+            author,
+            "마감 이후 기존 멤버 대화"
+        );
+    }
 
-        assertThat(RawStompTestClient.frameCommand(frame)).isEqualTo("MESSAGE");
-        assertThat(body.path("roomId").asLong()).isEqualTo(room.getId());
-        assertThat(body.path("sender").path("userId").asLong()).isEqualTo(author.getId());
-        assertThat(body.path("sender").path("nickname").asText()).isEqualTo(author.getNickname());
-        assertThat(body.path("content").asText()).isEqualTo("오늘 7시로 확정할게요");
-        assertThat(body.path("type").asText()).isEqualTo(ChatMessageType.TEXT.name());
-        assertThat(body.path("messageId").asLong()).isPositive();
-        assertThat(body.path("createdAt").asText()).isNotBlank();
-        assertThat(chatMessageRepository.countByRoomId(room.getId())).isEqualTo(1);
-        assertThat(savedMessage.getRoom().getId()).isEqualTo(room.getId());
-        assertThat(savedMessage.getSender().getId()).isEqualTo(author.getId());
-        assertThat(savedMessage.getContent()).isEqualTo("오늘 7시로 확정할게요");
-        assertThat(savedMessage.getType()).isEqualTo(ChatMessageType.TEXT);
-        assertThat(refreshedRoom.getLastMessageId()).isEqualTo(savedMessage.getId());
-        assertThat(refreshedRoom.getLastMessagePreview()).isEqualTo("오늘 7시로 확정할게요");
-        assertThat(refreshedRoom.getLastMessageAt()).isEqualTo(savedMessage.getCreatedAt());
+    @Test
+    @DisplayName("DELETED 게시글의 ACTIVE 멤버 메시지는 저장되고 구독자에게 브로드캐스트된다")
+    void sendMessageBroadcastsAndPersistsForDeletedPostActiveMembers() throws Exception {
+        ChatRoom deletedRoom = createRoomWithActiveMembers("deleted-room", PostStatus.DELETED, author, subscriber);
+
+        assertMessageBroadcastsAndPersists(
+            deletedRoom,
+            author,
+            subscriber,
+            """
+                {
+                  "content": "삭제 이후 기존 멤버 대화",
+                  "type": "TEXT"
+                }
+                """,
+            author,
+            "삭제 이후 기존 멤버 대화"
+        );
     }
 
     @Test
@@ -207,6 +224,47 @@ class ChatMessagingIntegrationTest extends IntegrationTestSupport {
         return jwtTokenProvider.generateAccessToken(user.getId(), user.getEmail());
     }
 
+    private void assertMessageBroadcastsAndPersists(
+        ChatRoom targetRoom,
+        User sender,
+        User receiver,
+        String payload,
+        User expectedSender,
+        String expectedContent
+    ) throws Exception {
+        RawStompTestClient.Connection subscriberConnection = stompClient.connect(accessToken(receiver));
+        subscriberConnection.send(RawStompTestClient.subscribeFrame(targetRoom.getId()));
+        subscriberConnection.assertNoFrame();
+
+        RawStompTestClient.Connection senderConnection = stompClient.connect(accessToken(sender));
+        senderConnection.send(RawStompTestClient.sendFrame(targetRoom.getId(), payload));
+
+        String frame = subscriberConnection.awaitFrame();
+        JsonNode body = RawStompTestClient.parseBody(objectMapper, frame);
+        ChatMessage savedMessage = chatMessageRepository.findAll().stream()
+            .findFirst()
+            .orElseThrow(() -> new AssertionError("저장된 메시지가 있어야 합니다."));
+        ChatRoom refreshedRoom = chatRoomRepository.findById(targetRoom.getId())
+            .orElseThrow(() -> new AssertionError("채팅방이 유지되어야 합니다."));
+
+        assertThat(RawStompTestClient.frameCommand(frame)).isEqualTo("MESSAGE");
+        assertThat(body.path("roomId").asLong()).isEqualTo(targetRoom.getId());
+        assertThat(body.path("sender").path("userId").asLong()).isEqualTo(expectedSender.getId());
+        assertThat(body.path("sender").path("nickname").asText()).isEqualTo(expectedSender.getNickname());
+        assertThat(body.path("content").asText()).isEqualTo(expectedContent);
+        assertThat(body.path("type").asText()).isEqualTo(ChatMessageType.TEXT.name());
+        assertThat(body.path("messageId").asLong()).isPositive();
+        assertThat(body.path("createdAt").asText()).isNotBlank();
+        assertThat(chatMessageRepository.countByRoomId(targetRoom.getId())).isEqualTo(1);
+        assertThat(savedMessage.getRoom().getId()).isEqualTo(targetRoom.getId());
+        assertThat(savedMessage.getSender().getId()).isEqualTo(expectedSender.getId());
+        assertThat(savedMessage.getContent()).isEqualTo(expectedContent);
+        assertThat(savedMessage.getType()).isEqualTo(ChatMessageType.TEXT);
+        assertThat(refreshedRoom.getLastMessageId()).isEqualTo(savedMessage.getId());
+        assertThat(refreshedRoom.getLastMessagePreview()).isEqualTo(expectedContent);
+        assertThat(refreshedRoom.getLastMessageAt()).isEqualTo(savedMessage.getCreatedAt());
+    }
+
     private User saveUser(String email, String nickname) {
         return userRepository.save(new User(
             email,
@@ -218,6 +276,14 @@ class ChatMessagingIntegrationTest extends IntegrationTestSupport {
     private ChatRoom createRoom(String title, PostStatus status) {
         Post post = postRepository.save(new Post(author, title, title + "-content", 4, status));
         return chatRoomRepository.save(new ChatRoom(post));
+    }
+
+    private ChatRoom createRoomWithActiveMembers(String title, PostStatus status, User... users) {
+        ChatRoom targetRoom = createRoom(title, status);
+        for (User user : users) {
+            addActiveMember(targetRoom, user);
+        }
+        return targetRoom;
     }
 
     private void addActiveMember(ChatRoom chatRoom, User user) {

--- a/src/test/java/io/github/nanmazino/chatrebuild/scenario/BaselineFlowScenarioTest.java
+++ b/src/test/java/io/github/nanmazino/chatrebuild/scenario/BaselineFlowScenarioTest.java
@@ -2,6 +2,7 @@ package io.github.nanmazino.chatrebuild.scenario;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -85,8 +86,8 @@ class BaselineFlowScenarioTest extends IntegrationTestSupport {
     }
 
     @Test
-    @DisplayName("회원가입부터 채팅방 조회까지 baseline 주요 흐름이 동작한다")
-    void baselineFlowWorksFromSignupToChatRoomQueries() throws Exception {
+    @DisplayName("회원가입부터 읽음 처리 후 unread 반영까지 baseline 주요 흐름이 동작한다")
+    void baselineFlowWorksFromSignupToReadSync() throws Exception {
         signUp("author@example.com", "Password123!", "author");
         signUp("member@example.com", "Password123!", "member");
 
@@ -157,6 +158,18 @@ class BaselineFlowScenarioTest extends IntegrationTestSupport {
         assertThat(latestHistoryMessage.path("messageId").asLong()).isEqualTo(messageId);
         assertThat(latestHistoryMessage.path("content").asText()).isEqualTo(messageContent);
         assertThat(latestHistoryMessage.path("sender").path("nickname").asText()).isEqualTo("author");
+
+        JsonNode readResponse = markAsRead(memberToken, roomId, messageId);
+        assertThat(readResponse.path("data").path("roomId").asLong()).isEqualTo(roomId);
+        assertThat(readResponse.path("data").path("lastReadMessageId").asLong()).isEqualTo(messageId);
+        assertThat(readResponse.path("data").path("lastReadAt").asText()).isNotBlank();
+
+        JsonNode refreshedRoomListResponse = getAuthorized("/api/chat-rooms", memberToken);
+        JsonNode refreshedRoomListItem = refreshedRoomListResponse.path("data").path("items").get(0);
+
+        assertThat(refreshedRoomListItem.path("roomId").asLong()).isEqualTo(roomId);
+        assertThat(refreshedRoomListItem.path("lastReadMessageId").asLong()).isEqualTo(messageId);
+        assertThat(refreshedRoomListItem.path("unreadCount").asLong()).isEqualTo(0L);
     }
 
     private void signUp(String email, String password, String nickname) throws Exception {
@@ -198,6 +211,20 @@ class BaselineFlowScenarioTest extends IntegrationTestSupport {
                     }
                     """.formatted(title, content)))
             .andExpect(status().isCreated())
+            .andReturn();
+
+        return toJson(result);
+    }
+
+    private JsonNode markAsRead(String accessToken, long roomId, long lastReadMessageId) throws Exception {
+        MvcResult result = perform(authorize(patch("/api/chat-rooms/" + roomId + "/read"), accessToken)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "lastReadMessageId": %d
+                    }
+                    """.formatted(lastReadMessageId)))
+            .andExpect(status().isOk())
             .andReturn();
 
         return toJson(result);


### PR DESCRIPTION
## 요약
- STOMP 메시지 저장/브로드캐스트 검증을 공용 헬퍼로 정리하고, 기존 ACTIVE 멤버가 `CLOSED`/`DELETED` 게시글 채팅방에서도 실제로 메시지를 주고받을 수 있는지 회귀 테스트로 고정했습니다.
- baseline 시나리오를 읽음 처리까지 확장해 메시지 조회 뒤 `PATCH /api/chat-rooms/{roomId}/read` 호출과 room list `unreadCount` 동기화를 한 흐름에서 검증하도록 보강했습니다.

## 관련 이슈
- Closes #53

## 변경 사항
- `ChatMessagingIntegrationTest`에 공통 검증 헬퍼를 도입하고, principal sender 강제 적용 검증은 유지한 채 `CLOSED`/`DELETED` 게시글의 기존 ACTIVE 멤버 채팅 허용 시나리오를 추가했습니다.
- `BaselineFlowScenarioTest`를 회원가입부터 읽음 처리 후 unread 반영까지 이어지는 시나리오로 확장하고, `lastReadMessageId` 및 `unreadCount` 갱신을 최종 응답 기준으로 확인하도록 수정했습니다.

## 검증
- `./gradlew.bat test --tests io.github.nanmazino.chatrebuild.chat.controller.ChatMessagingIntegrationTest --tests io.github.nanmazino.chatrebuild.scenario.BaselineFlowScenarioTest`
- `./gradlew.bat test --rerun-tasks`